### PR TITLE
Petite erreur de casse

### DIFF
--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -7,5 +7,5 @@ import { type RouteConfig, index, route } from "@react-router/dev/routes";
  */
 export default [
     index("routes/home.tsx"),
-    route("processor", "./routes/processor/processor.tsx"),
+    route("processor", "routes/processor/Processor.tsx"),
 ] satisfies RouteConfig;


### PR DESCRIPTION
Cette erreur de casse causait une erreur de build. Dorénavant, il faut écrire le chemin des fichiers de routes comme ils apparaissent dans la structure de fichier.