### PR TITLE
chore(ci/cd): md to pdf workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,38 @@
-name: Construction de l'installateur
+name: Construction de l'installateur et de la documentation
 
 on:
   push:
     branches:
       - main
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
+      - '**.md'
+
 jobs:
-    create-release:
+  detect-changes:
+    name: Détecter les changements
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Filtrer les changements
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'frontend/**'
+              - 'backend/**'
+            docs:
+              - 'GuideCodeMachine.md'
+
+  create-release:
+      needs: detect-changes
+      if: needs.detect-changes.outputs.code == 'true'
       name: Publier une release
       runs-on: ubuntu-latest
       outputs:
@@ -28,7 +55,9 @@ jobs:
             GH_TOKEN: ${{ github.token }}
           run: gh release create ${{ steps.get-version.outputs.version }} -d -F release-notes.md
         
-    build-backend:
+  build-backend:
+        needs: detect-changes
+        if: needs.detect-changes.outputs.code == 'true'
         defaults:
             run:
                 shell: bash -ieo pipefail {0}
@@ -59,7 +88,9 @@ jobs:
                 name: backend-build
                 path: ./backend/target/scala-2.12/Accumulator_CPU_Chisel-assembly-0.1.0.jar
 
-    build-frontend:
+  build-frontend:
+      needs: detect-changes
+      if: needs.detect-changes.outputs.code == 'true'
       name: Construction du frontend
       runs-on: ubuntu-latest
       steps:
@@ -93,10 +124,11 @@ jobs:
             name: frontend-build
             path: ./frontend/build
 
-    package-mac:
+  package-mac:
       name: Emballage de l'application pour mac
       runs-on: macos-latest
-      needs: [build-frontend, build-backend, create-release]
+      needs: [detect-changes, build-frontend, build-backend, create-release]
+      if: needs.detect-changes.outputs.code == 'true'
       steps:
         - name: Récupérer le code
           uses: actions/checkout@v4
@@ -140,13 +172,14 @@ jobs:
             tag: ${{ needs.create-release.outputs.version }}
           run: gh release upload $tag frontend/dist/CodeMachine-$tag-mac-universal.dmg
 
-    package-linux-windows:
+  package-linux-windows:
       strategy:
         matrix:
           os: [ubuntu-latest, windows-latest]
           arch: [x64, arm64]
       runs-on: ${{ matrix.os }}
-      needs: [build-frontend, build-backend, create-release]
+      needs: [detect-changes, build-frontend, build-backend, create-release]
+      if: needs.detect-changes.outputs.code == 'true'
       name: Emballage pour ${{ matrix.os }}-${{ matrix.arch }}
       steps:
         - name: Récupérer le code
@@ -205,11 +238,35 @@ jobs:
             tag: ${{ needs.create-release.outputs.version }}
           if: runner.os == 'Linux' && matrix.arch == 'arm64'
           run: gh release upload $tag frontend/dist/CodeMachine-$tag-linux-${{ matrix.arch }}.AppImage
+          
+  publish-docs:
+      name: Publier la documentation
+      runs-on: ubuntu-latest
+      needs: [detect-changes, create-release]
+      if: needs.detect-changes.outputs.code == 'true'
+      steps:
+        - uses: actions/checkout@v4
+  
+        - name: Installer Pandoc
+          run: sudo apt-get install -y pandoc texlive-xetex texlive-fonts-recommended
+  
+        - name: Convertir MD en PDF
+          run: |
+            TAG=${{ needs.create-release.outputs.version }}
+            pandoc GuideCodeMachine.md -o GuideCodeMachine-$TAG.pdf --pdf-engine=xelatex
+  
+        - name: Uploader le PDF dans la nouvelle release
+          env:
+            GH_TOKEN: ${{ github.token }}
+          run: |
+            TAG=${{ needs.create-release.outputs.version }}
+            gh release upload $TAG GuideCodeMachine-$TAG.pdf
 
-    save-release:
+  save-release:
       name: Sauvegarder la distribution
       runs-on: ubuntu-latest
-      needs: [create-release, package-linux-windows, package-mac]
+      needs: [detect-changes, create-release, package-linux-windows, package-mac, publish-docs]
+      if: needs.detect-changes.outputs.code == 'true'
       steps:
         - name: Récupérer le code
           uses: actions/checkout@v4
@@ -219,3 +276,37 @@ jobs:
             GH_TOKEN: ${{ github.token }}
             tag: ${{ needs.create-release.outputs.version }}
           run: gh release edit $tag --draft=false
+
+  update-docs:
+    name: Mettre à jour la documentation
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.docs == 'true' && needs.detect-changes.outputs.code == 'false'
+    steps:
+      - uses: actions/checkout@v4
+  
+      - name: Installer Pandoc
+        run: sudo apt-get install -y pandoc texlive-xetex texlive-fonts-recommended
+  
+      - name: Récupérer le tag de la dernière release
+        id: get-tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+  
+      - name: Convertir MD en PDF
+        run: |
+          TAG=${{ steps.get-tag.outputs.tag }}
+          pandoc GuideCodeMachine.md -o GuideCodeMachine-$TAG.pdf --pdf-engine=xelatex
+  
+      - name: Remplacer le PDF dans la dernière release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG=${{ steps.get-tag.outputs.tag }}
+          gh release view $TAG --json assets --jq '.assets[].name' \
+            | grep '^GuideCodeMachine-' \
+            | xargs -I {} gh release delete-asset $TAG {} -y || true
+          gh release upload $TAG GuideCodeMachine-$TAG.pdf


### PR DESCRIPTION
Automatically builds or updates GuideCodeMachine.pdf on modification of GuideCodeMachine.md and new releases. The pdf will live with the release assets. On updates of doc, it will overwrite the current release's pdf.